### PR TITLE
Rename module (update cargo.toml)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "assembly_simulator"
-version = "0.1.0"
+name = "massa-sc-runtime"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Rename into `massa-sc-runtime` and update version (preparing for the tag v0.3.0)