### PR TITLE
Breaking optim of interface - remove warnings

### DIFF
--- a/src/abi_impl.rs
+++ b/src/abi_impl.rs
@@ -382,7 +382,7 @@ fn pointer_from_string(env: &Env, value: &str) -> ABIResult<StringPtr> {
 /// Tooling, return a StringPtr allocated from bytes with utf8 parsing
 fn pointer_from_utf8(env: &Env, value: &[u8]) -> ABIResult<StringPtr> {
     match std::str::from_utf8(value) {
-        Ok(data) => match StringPtr::alloc(&data.into(), &env.wasm_env) {
+        Ok(data) => match StringPtr::alloc(&data.to_string(), &env.wasm_env) {
             Ok(ptr) => Ok(*ptr),
             Err(err) => abi_bail!(err),
         },

--- a/src/abi_impl.rs
+++ b/src/abi_impl.rs
@@ -197,7 +197,7 @@ pub(crate) fn assembly_script_hash(env: &Env, value: i32) -> ABIResult<i32> {
     sub_remaining_gas(env, settings::metering_hash_const())?;
     let memory = get_memory!(env);
     let value = read_string_and_sub_gas(env, memory, value, settings::metering_hash_per_byte())?;
-    match env.interface.hash(&value.as_bytes().to_vec()) {
+    match env.interface.hash(value.as_bytes()) {
         Ok(h) => Ok(pointer_from_string(env, &h)?.offset() as i32),
         Err(err) => abi_bail!(err),
     }
@@ -210,7 +210,7 @@ pub(crate) fn assembly_script_set_data(env: &Env, key: i32, value: i32) -> ABIRe
     let key = read_string_and_sub_gas(env, memory, key, settings::metering_set_data_key_mult())?;
     let value =
         read_string_and_sub_gas(env, memory, value, settings::metering_set_data_value_mult())?;
-    if let Err(err) = env.interface.set_data(&key, &value.as_bytes().to_vec()) {
+    if let Err(err) = env.interface.set_data(&key, value.as_bytes()) {
         abi_bail!(err)
     }
     Ok(())
@@ -254,10 +254,7 @@ pub(crate) fn assembly_script_set_data_for(
     let value =
         read_string_and_sub_gas(env, memory, value, settings::metering_set_data_value_mult())?;
     let address = get_string(memory, address)?;
-    if let Err(err) = env
-        .interface
-        .set_data_for(&address, &key, &value.as_bytes().to_vec())
-    {
+    if let Err(err) = env.interface.set_data_for(&address, &key, value.as_bytes()) {
         abi_bail!(err)
     }
     Ok(())
@@ -334,7 +331,7 @@ pub(crate) fn assembly_script_signature_verify(
     let public_key = get_string(memory, public_key)?;
     match env
         .interface
-        .signature_verify(&data.as_bytes().to_vec(), &signature, &public_key)
+        .signature_verify(data.as_bytes(), &signature, &public_key)
     {
         Err(err) => abi_bail!(err),
         Ok(false) => Ok(0),
@@ -375,17 +372,17 @@ pub(crate) fn assembly_script_get_time(env: &Env) -> ABIResult<i64> {
 }
 
 /// Tooling, return a StringPtr allocated from a String
-fn pointer_from_string(env: &Env, value: &String) -> ABIResult<StringPtr> {
-    match StringPtr::alloc(value, &env.wasm_env) {
+fn pointer_from_string(env: &Env, value: &str) -> ABIResult<StringPtr> {
+    match StringPtr::alloc(&value.into(), &env.wasm_env) {
         Ok(ptr) => Ok(*ptr),
         Err(err) => abi_bail!(err),
     }
 }
 
 /// Tooling, return a StringPtr allocated from bytes with utf8 parsing
-fn pointer_from_utf8(env: &Env, value: &Vec<u8>) -> ABIResult<StringPtr> {
+fn pointer_from_utf8(env: &Env, value: &[u8]) -> ABIResult<StringPtr> {
     match std::str::from_utf8(value) {
-        Ok(data) => match StringPtr::alloc(&data.to_string(), &env.wasm_env) {
+        Ok(data) => match StringPtr::alloc(&data.into(), &env.wasm_env) {
             Ok(ptr) => Ok(*ptr),
             Err(err) => abi_bail!(err),
         },

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -45,11 +45,11 @@ impl Interface for TestInterface {
         self.0
             .lock()
             .unwrap()
-            .insert("print".to_string(), message.as_bytes().to_vec());
+            .insert("print".into(), message.as_bytes().to_vec());
         Ok(())
     }
 
-    fn get_data(&self, _: &String) -> Result<Bytecode> {
+    fn get_data(&self, _: &str) -> Result<Bytecode> {
         match self.0.lock().unwrap().clone().get(&"print".to_string()) {
             Some(bytes) => Ok(bytes.clone()),
             _ => bail!("Cannot find data"),

--- a/src/types.rs
+++ b/src/types.rs
@@ -84,35 +84,35 @@ pub trait Interface: Send + Sync + InterfaceClone {
     ///
     /// Note:
     /// The execution lib will allways use the current context address for the update
-    fn set_data_for(&self, _address: &Address, _key: &MassaHash, _value: &Vec<u8>) -> Result<()> {
+    fn set_data_for(&self, _address: &Address, _key: &MassaHash, _value: &[u8]) -> Result<()> {
         bail!("unimplemented function set_data_for in interface")
     }
 
-    fn get_data(&self, _key: &String) -> Result<Vec<u8>> {
+    fn get_data(&self, _key: &str) -> Result<Vec<u8>> {
         bail!("unimplemented function get_data in interface")
     }
 
-    fn set_data(&self, _key: &String, _value: &Vec<u8>) -> Result<()> {
+    fn set_data(&self, _key: &str, _value: &[u8]) -> Result<()> {
         bail!("unimplemented function set_data in interface")
     }
 
-    fn has_data(&self, _key: &String) -> Result<bool> {
+    fn has_data(&self, _key: &str) -> Result<bool> {
         bail!("unimplemented function has_data in interface")
     }
 
-    fn has_data_for(&self, _address: &Address, _key: &String) -> Result<bool> {
+    fn has_data_for(&self, _address: &Address, _key: &str) -> Result<bool> {
         bail!("unimplemented function has_data_for in interface")
     }
 
     // Hash data
-    fn hash(&self, _data: &Vec<u8>) -> Result<MassaHash> {
+    fn hash(&self, _data: &[u8]) -> Result<MassaHash> {
         bail!("unimplemented function hash in interface")
     }
 
     // Verify signature
     fn signature_verify(
         &self,
-        _data: &Vec<u8>,
+        _data: &[u8],
         _signature: &Signature,
         _public_key: &PublicKey,
     ) -> Result<bool> {


### PR DESCRIPTION
Remove all warnings fro sc-runtime.

_:warning: Change the interface_

For some conversions I used  `.into()`, I don't know if it is more appropriated but checks passed.
