### PR TITLE
Fix remaining gas in subcall.

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -68,7 +68,7 @@ pub fn get_remaining_points(env: &Env) -> ABIResult<u64> {
 /// Set remaining metering points
 /// Should be equivalent to
 /// https://github.com/wasmerio/wasmer/blob/8f2e49d52823cb7704d93683ce798aa84b6928c8/lib/middlewares/src/metering.rs#L343
-fn set_remaining_points(env: &Env, points: u64) -> ABIResult<()> {
+pub fn set_remaining_points(env: &Env, points: u64) -> ABIResult<()> {
     match env.remaining_points.as_ref() {
         Some(remaining_points) => {
             if remaining_points.set(points.into()).is_err() {


### PR DESCRIPTION
The gas consumed in a sub call isn't taken into account in the parent call.