### PR TITLE
Fix as-ffi-bindings version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
 [[package]]
 name = "as-ffi-bindings"
 version = "0.2.1"
-source = "git+https://github.com/massalabs/as-ffi-bindings.git?branch=fix_memory_errors#a0860c12b4a4544a20ce5612064254730bfce012"
+source = "git+https://github.com/massalabs/as-ffi-bindings.git#e7c0e36494686f4c5be49c90b2439d994ecd12c8"
 dependencies = [
  "anyhow",
  "wasmer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "massa-sc-runtime"
-version = "0.3.0"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "as-ffi-bindings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa-sc-runtime"
-version = "0.3.0"
+version = "0.6.5"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ lazy_static = "1"
 serde = "1.0"
 serde_json = "1.0"
 wasmer = "2.2.1"
-as-ffi-bindings = { "git" = "https://github.com/massalabs/as-ffi-bindings.git", branch = "fix_memory_errors" }
+as-ffi-bindings = { "git" = "https://github.com/massalabs/as-ffi-bindings.git" }
 wasmer-compiler-singlepass = "2.2.1"
 wasmer-engine-universal = "2.2.1"
 wasmer-middlewares = "2.2.1"


### PR DESCRIPTION
Fix dependency on branch that do not exist anymore 

I will tag a 0.6.5 after this merge.