### PR TITLE
Rename two ABI names

### DIFF
--- a/src/execution/as_abi.rs
+++ b/src/execution/as_abi.rs
@@ -839,7 +839,7 @@ pub(crate) fn assembly_script_local_call(
 
 /// Check whether or not the caller has write access in the current context
 #[named]
-pub fn assembly_caller_has_write_access(mut ctx: FunctionEnvMut<ASEnv>) -> ABIResult<i32> {
+pub fn assembly_script_caller_has_write_access(mut ctx: FunctionEnvMut<ASEnv>) -> ABIResult<i32> {
     let env = ctx.data().clone();
     sub_remaining_gas_abi(&env, &mut ctx, function_name!())?;
     Ok(env.get_interface().caller_has_write_access()? as i32)
@@ -847,7 +847,7 @@ pub fn assembly_caller_has_write_access(mut ctx: FunctionEnvMut<ASEnv>) -> ABIRe
 
 /// Check whether or not the given function exists at the given address
 #[named]
-pub fn assembly_function_exists(
+pub fn assembly_script_function_exists(
     mut ctx: FunctionEnvMut<ASEnv>,
     address: i32,
     function: i32,

--- a/src/execution/as_execution.rs
+++ b/src/execution/as_execution.rs
@@ -218,8 +218,8 @@ impl MassaModule for ASModule {
                 "assembly_script_get_bytecode_for" => Function::new_typed_with_env(store, &fenv, assembly_script_get_bytecode_for),
                 "assembly_script_local_call" => Function::new_typed_with_env(store, &fenv, assembly_script_local_call),
                 "assembly_script_local_execution" => Function::new_typed_with_env(store, &fenv, assembly_script_local_execution),
-                "assembly_caller_has_write_access" => Function::new_typed_with_env(store, &fenv, assembly_caller_has_write_access),
-                "assembly_function_exists" => Function::new_typed_with_env(store, &fenv, assembly_function_exists),
+                "assembly_script_caller_has_write_access" => Function::new_typed_with_env(store, &fenv, assembly_script_caller_has_write_access),
+                "assembly_script_function_exists" => Function::new_typed_with_env(store, &fenv, assembly_script_function_exists),
             },
         };
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -99,8 +99,8 @@ impl Default for GasCosts {
         abi_costs.insert(String::from("assembly_script_local_execution"), 11);
         abi_costs.insert(String::from("assembly_script_get_bytecode"), 11);
         abi_costs.insert(String::from("assembly_script_get_bytecode_for"), 11);
-        abi_costs.insert(String::from("assembly_caller_has_write_access"), 11);
-        abi_costs.insert(String::from("assembly_function_exists"), 11);
+        abi_costs.insert(String::from("assembly_script_caller_has_write_access"), 11);
+        abi_costs.insert(String::from("assembly_script_function_exists"), 11);
         abi_costs.insert(String::from("assembly_script_seed"), 11);
         abi_costs.insert(String::from("assembly_script_abort"), 11);
         abi_costs.insert(String::from("assembly_script_date_now"), 11);


### PR DESCRIPTION
#196 

- [x] assembly_caller_has_write_access => assembly_script_caller_has_write_access
- [x] assembly_function_exists => assembly_script_function_exists
- [x] rename corresponding massa-sdk exports
- [x] rename assembly_script_get_bytecode_for massa-sdk export