### PR TITLE
Switch to gh merge queues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main, staging, trying]
   pull_request:
     branches: [main, 'testnet_*']
+  merge_group:
+    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
   # Code documentation and coverage will be run only on main branch
   coverage:
     runs-on: ubuntu-latest
-    #if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
   # Code documentation and coverage will be run only on main branch
   coverage:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    #if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: -- -A clippy::uninlined-format-args
 
-  # Full cross-platform tests required by bors to merge on main branch
+  # Full cross-platform tests required to merge on main branch
   full:
     # if: github.ref == 'refs/heads/staging'
     name: full
@@ -116,7 +116,7 @@ jobs:
           command: test
           args: --features gas_calibration
 
-  build: # quick hack because bors wrongly detect matrix jobs status
+  build: # quick hack because bors wrongly detect matrix jobs status. Note: May not be needed anymore with GitHub Merge Queues
     # if: github.ref == 'refs/heads/staging'
     needs: full
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.72.1
+          toolchain: 1.74.1
           components: rustfmt
           override: true
       - uses: Swatinem/rust-cache@v1
@@ -43,7 +43,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.72.1
+          toolchain: 1.74.1
           override: true
       - uses: Swatinem/rust-cache@v1
       - uses: arduino/setup-protoc@v1
@@ -66,7 +66,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.72.1
+          toolchain: 1.74.1
           components: clippy
           override: true
       - uses: Swatinem/rust-cache@v1
@@ -98,7 +98,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.72.1
+          toolchain: 1.74.1
           override: true
       - uses: Swatinem/rust-cache@v1
       - uses: arduino/setup-protoc@v1
@@ -134,7 +134,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.72.1
+          toolchain: 1.74.1
           override: true
       - uses: arduino/setup-protoc@v1
         with:
@@ -168,7 +168,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.72.1
+          toolchain: 1.74.1
           components: rustfmt
           override: true
       - uses: arduino/setup-protoc@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
           command: test
           args: --features gas_calibration
 
-  build: # quick hack because bors wrongly detect matrix jobs status. Note: May not be needed anymore with GitHub Merge Queues
+  build: # quick hack because bors wrongly detect matrix jobs status. Note: May not be needed anymore with GitHub Merge Queues.
     # if: github.ref == 'refs/heads/staging'
     needs: full
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all-features --no-fail-fast
+          args: --features gas_calibration,testing,dumper --no-fail-fast
         env:
           CARGO_INCREMENTAL: "0"
           RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.74.1
+          toolchain: 1.76.0-nightly
           override: true
       - uses: arduino/setup-protoc@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.76.0-nightly
+          toolchain: nightly
           override: true
       - uses: arduino/setup-protoc@v1
         with:

--- a/bors.toml
+++ b/bors.toml
@@ -1,2 +1,0 @@
-status = ["build"]
-delete_merged_branches = true


### PR DESCRIPTION
Note: this PR repairs the "Coverage" CI job that runs on main. It needed nightly only compiler flags.

Blocked: needs repo configuration

On massa and massa-sc-runtime :
- [x] Remove access to the no longer running Bors App: https://github.com/apps/bors
- [x] Configure merge queues: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#managing-a-merge-queue
  - [x] Check "Require merge queue" in the branch protection rule page.
  - [x] Set "Merge method" to squash
  - [x] Set "Build concurrency" to ? ( 5 ? )
  - [x] Check "Only merge non-failing pull requests"
  - [x] Set "Status check timeout" to ? (36000 = 10 hours ?)
  - [x] Set "Merge limits":
    - [x] Set "Minimum pull requests to merge" to 1
    - [x] Set "Maximum pull requests to merge" to ? ( 5 ? )
- [ ] Merge PRs that configure the Merge queues:
  - [ ] Massa: https://github.com/massalabs/massa/pull/4597
  - [ ] Massa-sc-runtime: https://github.com/massalabs/massa-sc-runtime/pull/322